### PR TITLE
Update issue template to capture namespace-to-DNS mappings

### DIFF
--- a/.github/ISSUE_TEMPLATE/cert-automation-request.yml
+++ b/.github/ISSUE_TEMPLATE/cert-automation-request.yml
@@ -22,23 +22,19 @@ body:
     validations:
       required: true
   - type: textarea
-    id: namespaces
+    id: namespace_dns_mappings
     attributes:
-      label: Namespaces
-      description: One namespace per line.
+      label: Namespace and DNS Names
+      description: Provide each namespace followed by the DNS names for that namespace. Repeat for additional namespaces.
       placeholder: |-
-        platform-scope
-        pie-grafana
-    validations:
-      required: true
-  - type: textarea
-    id: dns_names
-    attributes:
-      label: DNS Names
-      description: One DNS name per line.
-      placeholder: |-
-        example01.platform-scope.pod.cac.corp.aks.sunlife.com
-        example02.platform-scope.pod.cac.corp.aks.sunlife.com
+        namespace: platform-scope
+        dns:
+          - example01.platform-scope.pod.cac.corp.aks.sunlife.com
+          - example02.platform-scope.pod.cac.corp.aks.sunlife.com
+
+        namespace: pie-grafana
+        dns:
+          - example01.pie-grafana.pod.cac.corp.aks.sunlife.com
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
### Motivation
- Make the issue form unambiguous by pairing each namespace with its DNS names so requesters can indicate which DNS entries belong to which namespace instead of providing two separate lists.

### Description
- Replace the separate `namespaces` and `dns_names` textarea inputs with a single `namespace_dns_mappings` textarea in `.github/ISSUE_TEMPLATE/cert-automation-request.yml` and provide a structured placeholder showing `namespace:` and `dns:` list entries for each namespace.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696af52b0c388324b5d6c362c2cf5ea2)